### PR TITLE
Using atom.element instead of name[0] in output_pdb_as_xyzrn

### DIFF
--- a/source/triangulation/xyzrn.py
+++ b/source/triangulation/xyzrn.py
@@ -25,7 +25,7 @@ def output_pdb_as_xyzrn(pdbfilename, xyzrnfilename):
         resname = residue.get_resname()
         reskey = residue.get_id()[1]
         chain = residue.get_parent().get_id()
-        atomtype = name[0]
+        atomtype = atom.element
 
         color = "Green"
         coords = None


### PR DESCRIPTION
Sorry if there's a reason `name[0]` was chosen on purpose, but it is unreliable for atoms such as "1H"