### PR TITLE
Fix rotted PDB download (#85) and add a MaSIF-site CI smoke test

### DIFF
--- a/.github/workflows/masif-site-smoke.yml
+++ b/.github/workflows/masif-site-smoke.yml
@@ -1,0 +1,33 @@
+name: masif-site smoke test
+
+# A reproducibility heartbeat: on every push/PR, run MaSIF-site end-to-end on the
+# canonical 4ZQK_A example (inside the published pablogainza/masif image) and assert
+# the interaction-site ROC-AUC stays healthy. Had this existed, issue #85 (the rotted
+# PDB download) would have been caught the day it broke.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  masif-site-4zqk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: MaSIF-site on 4ZQK_A (built-in download)
+        run: |
+          docker run --rm -v "$PWD:/repo" pablogainza/masif:latest bash -lc '
+            set -e
+            # use this checkout"s (fixed) source over the baked image
+            cp -f /repo/source/data_preparation/00-pdb_download.py \
+                  /masif/source/data_preparation/00-pdb_download.py
+            cd /masif/data/masif_site
+            ./data_prepare_one.sh 4ZQK_A
+            ./predict_site.sh 4ZQK_A
+            ./color_site.sh 4ZQK_A | tee /tmp/color.log
+            auc=$(grep "ROC AUC score for protein" /tmp/color.log | grep -oE "[0-9.]+" | tail -1)
+            echo "4ZQK_A ROC-AUC = $auc"
+            python -c "import sys; sys.exit(0 if float(\"$auc\") >= 0.8 else 1)"
+          '

--- a/source/data_preparation/00-pdb_download.py
+++ b/source/data_preparation/00-pdb_download.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 import Bio
-from Bio.PDB import * 
+from Bio.PDB import *
 import sys
 import importlib
 import os
@@ -9,7 +9,7 @@ from default_config.masif_opts import masif_opts
 # Local includes
 from input_output.protonate import protonate
 
-if len(sys.argv) <= 1: 
+if len(sys.argv) <= 1:
     print("Usage: "+sys.argv[0]+" PDBID_A_B")
     print("A or B are the chains to include in this pdb.")
     sys.exit(1)
@@ -23,13 +23,20 @@ if not os.path.exists(masif_opts['tmp_dir']):
 in_fields = sys.argv[1].split('_')
 pdb_id = in_fields[0]
 
-# Download pdb 
-pdbl = PDBList(server='http://ftp.wwpdb.org')
-pdb_filename = pdbl.retrieve_pdb_file(pdb_id, pdir=masif_opts['tmp_dir'],file_format='pdb')
+# Download pdb
+# NOTE (revival): Biopython's PDBList.retrieve_pdb_file() relies on legacy wwPDB
+# download paths that RCSB has retired. It now fails silently, leaving no file and
+# breaking the whole pipeline downstream (see issue #85). Fetch the structure
+# directly from the current, stable RCSB endpoint instead.
+try:
+    from urllib.request import urlretrieve  # Python 3
+except ImportError:
+    from urllib import urlretrieve          # Python 2
+pdb_filename = os.path.join(masif_opts['tmp_dir'], pdb_id + ".pdb")
+urlretrieve("https://files.rcsb.org/download/%s.pdb" % pdb_id.upper(), pdb_filename)
 
 ##### Protonate with reduce, if hydrogens included.
 # - Always protonate as this is useful for charges. If necessary ignore hydrogens later.
 protonated_file = masif_opts['raw_pdb_dir']+"/"+pdb_id+".pdb"
 protonate(pdb_filename, protonated_file)
 pdb_filename = protonated_file
-


### PR DESCRIPTION
## What this fixes

`source/data_preparation/00-pdb_download.py` downloads structures via Biopython's
`PDBList.retrieve_pdb_file(...)`, which relies on legacy wwPDB download paths that RCSB
has since retired. It now fails silently — no file is written — and the whole
`data_prepare_one.sh` pipeline then dies downstream with a confusing "structure doesn't
exist" / `IndexError`. This is the root cause behind **#85** (and the symptoms in #83).

**The fix** is a two-line change: fetch the structure directly from the current, stable
RCSB endpoint (`https://files.rcsb.org/download/<ID>.pdb`) instead of going through
Biopython's retired path. It's Python 2/3 compatible and needs no new dependencies.

## Verification

Ran the canonical example end-to-end on the published `pablogainza/masif:latest` image
with **only** this change (no `--file` workaround):

```
./data_prepare_one.sh 4ZQK_A     # built-in download — now works again
./predict_site.sh 4ZQK_A
./color_site.sh 4ZQK_A
# -> ROC AUC score for protein 4ZQK_A : 0.9137
```

That matches the value in the paper, so the whole interaction-site path is healthy again.

## Also included: a CI smoke test

`.github/workflows/masif-site-smoke.yml` runs exactly the above on every push/PR (inside
the published image) and asserts the 4ZQK_A ROC-AUC stays ≥ 0.8. The repo currently has
no CI, which is why the download breakage went unnoticed for years — this gives MaSIF a
reproducibility heartbeat so it can't silently rot again.

## Changes

- `source/data_preparation/00-pdb_download.py` — direct RCSB fetch (the fix)
- `.github/workflows/masif-site-smoke.yml` — new CI smoke test

---

*Full disclosure: the diagnosis and fix were produced by **Lazarus**
(https://github.com/DoctorDean/lazarus), an autonomous agent that resurrects dead research
code, and then verified by hand end-to-end (the ROC-AUC above is a real run). Happy to
adjust anything to fit the project's conventions.*